### PR TITLE
fix: empresa y tipo en la base de datos aparezcían como strings

### DIFF
--- a/src/common/pipes/empty_object.pipe.ts
+++ b/src/common/pipes/empty_object.pipe.ts
@@ -1,5 +1,7 @@
 import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
 
+//Este pipe se usa para vereficiar que no se mande una petición patch vacía
+
 @Injectable()
 export class EmptyObjectPipe implements PipeTransform {
   transform(value: Record<string, any>): Record<string, any> {

--- a/src/common/pipes/transform_objectId_fields.pipe.ts
+++ b/src/common/pipes/transform_objectId_fields.pipe.ts
@@ -1,0 +1,22 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+import { Types } from 'mongoose';
+
+//Este pipe se utiliza para transformar campos de tipo string a ObjectId para subirlos a la base de datos
+
+@Injectable()
+export class TransformObjectIdFieldsPipe implements PipeTransform {
+  constructor(private readonly fields: string[]) {}
+
+  transform(value: Record<string, any>) {
+    for (const field of this.fields) {
+      const val: unknown = value[field];
+      if (val !== undefined) {
+        if (typeof val !== 'string' || !Types.ObjectId.isValid(val)) {
+          throw new BadRequestException(`${field} is not a valid ObjectId`);
+        }
+        value[field] = new Types.ObjectId(val);
+      }
+    }
+    return value;
+  }
+}

--- a/src/common/pipes/validate_Empresa_exists.pipe.ts
+++ b/src/common/pipes/validate_Empresa_exists.pipe.ts
@@ -1,0 +1,31 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Empresa, EmpresaDocument } from 'src/empresa/schemas/empresa.schema';
+
+//Este pipe se utiliza para validar si la empresa existe en la base de datos
+
+@Injectable()
+export class ValidateEmpresaExistsPipe implements PipeTransform {
+  constructor(
+    @InjectModel(Empresa.name)
+    private empresaModel: Model<EmpresaDocument>,
+  ) {}
+
+  async transform(value: Record<string, any>) {
+    if (value.empresa === undefined) {
+      return value;
+    }
+
+    if (!Types.ObjectId.isValid(String(value.empresa))) {
+      throw new BadRequestException('empresa debe ser un ObjectId válido');
+    }
+
+    const exists = await this.empresaModel.exists({ _id: value.empresa });
+    if (!exists) {
+      throw new BadRequestException('Empresa no existente en la base de datos');
+    }
+
+    return value;
+  }
+}

--- a/src/vehiculo/vehiculo.controller.ts
+++ b/src/vehiculo/vehiculo.controller.ts
@@ -13,6 +13,8 @@ import { UpdateVehiculoDto } from './dto/update-vehiculo.dto';
 import { ParseObjectIdPipe } from '@nestjs/mongoose';
 import { EmptyObjectPipe } from 'src/common/pipes/empty_object.pipe';
 import { ValidateTipoVehiculoExistsPipe } from 'src/common/pipes/validate_TipoVehiculo_exists.pipe';
+import { ValidateEmpresaExistsPipe } from 'src/common/pipes/validate_Empresa_exists.pipe';
+import { TransformObjectIdFieldsPipe } from 'src/common/pipes/transform_objectId_fields.pipe';
 
 @Controller('vehiculo')
 export class VehiculoController {
@@ -20,7 +22,12 @@ export class VehiculoController {
 
   @Post()
   async create(
-    @Body(ValidateTipoVehiculoExistsPipe) createVehiculoDto: CreateVehiculoDto,
+    @Body(
+      ValidateTipoVehiculoExistsPipe,
+      ValidateEmpresaExistsPipe,
+      new TransformObjectIdFieldsPipe(['tipo', 'empresa']),
+    )
+    createVehiculoDto: CreateVehiculoDto,
   ) {
     return this.vehiculoService.create(createVehiculoDto);
   }
@@ -38,7 +45,12 @@ export class VehiculoController {
   @Patch(':id')
   update(
     @Param('id', ParseObjectIdPipe) id: string,
-    @Body(EmptyObjectPipe, ValidateTipoVehiculoExistsPipe)
+    @Body(
+      EmptyObjectPipe,
+      ValidateTipoVehiculoExistsPipe,
+      ValidateEmpresaExistsPipe,
+      new TransformObjectIdFieldsPipe(['tipo', 'empresa']),
+    )
     updateVehiculoDto: UpdateVehiculoDto,
   ) {
     return this.vehiculoService.update(id, updateVehiculoDto);


### PR DESCRIPTION
También se separó el pipe que validaba si una empresa y tipo de vehículo estaban en la base de datos antes de hacer un patch o post, con el objetivo de que sean más reutilizables.